### PR TITLE
Emit cache metadata for analyzer (#47)

### DIFF
--- a/packages/analyzer/src/lib/__tests__/cacheMetadata.test.ts
+++ b/packages/analyzer/src/lib/__tests__/cacheMetadata.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { collectCacheMetadata } from '../cacheMetadata';
+
+const toArray = <T>(set: Set<T>) => Array.from(set);
+
+describe('collectCacheMetadata', () => {
+  it('captures fetch cache options and tags', () => {
+    const source = `
+      export async function loader() {
+        await fetch('https://example.com', {
+          cache: 'no-store',
+          next: { tags: ['products', layoutTag], revalidate: 120 },
+          headers: { 'x-next-cache-tags': 'promo, _N_T_/internal' },
+        });
+      }
+    `;
+
+    const meta = collectCacheMetadata({ sourceText: source });
+
+    expect(toArray(meta.cacheModes)).toEqual(['no-store']);
+    expect(toArray(meta.revalidateSeconds)).toEqual([120]);
+    expect(meta.hasRevalidateFalse).toBe(false);
+    expect(toArray(meta.tags).sort()).toEqual(['products', 'promo']);
+  });
+
+  it('captures revalidateTag and revalidatePath calls', () => {
+    const source = `
+      import { revalidatePath, revalidateTag } from 'next/cache';
+
+      export async function action() {
+        await revalidateTag('products');
+        revalidatePath('/dashboard');
+        revalidateTag(tagFromArgs);
+      }
+    `;
+
+    const meta = collectCacheMetadata({ sourceText: source });
+
+    expect(toArray(meta.revalidateTagCalls)).toEqual(['products']);
+    expect(toArray(meta.revalidatePathCalls)).toEqual(['/dashboard']);
+  });
+
+  it('tracks explicit disable of revalidation', () => {
+    const source = `
+      export async function loader() {
+        await fetch('https://example.com', {
+          next: { revalidate: false }
+        });
+      }
+    `;
+
+    const meta = collectCacheMetadata({ sourceText: source });
+
+    expect(meta.hasRevalidateFalse).toBe(true);
+  });
+});

--- a/packages/analyzer/src/lib/cacheMetadata.ts
+++ b/packages/analyzer/src/lib/cacheMetadata.ts
@@ -1,0 +1,195 @@
+import * as ts from 'typescript';
+
+export interface FileCacheMetadata {
+  tags: Set<string>;
+  cacheModes: Set<'force-cache' | 'no-store'>;
+  revalidateSeconds: Set<number>;
+  hasRevalidateFalse: boolean;
+  revalidateTagCalls: Set<string>;
+  revalidatePathCalls: Set<string>;
+}
+
+interface CollectOptions {
+  sourceText: string;
+}
+
+const CACHE_LITERAL_VALUES = new Set(['force-cache', 'no-store']);
+
+function createEmptyMetadata(): FileCacheMetadata {
+  return {
+    tags: new Set<string>(),
+    cacheModes: new Set<'force-cache' | 'no-store'>(),
+    revalidateSeconds: new Set<number>(),
+    hasRevalidateFalse: false,
+    revalidateTagCalls: new Set<string>(),
+    revalidatePathCalls: new Set<string>(),
+  };
+}
+
+function extractStaticString(node: ts.Expression): string | null {
+  if (ts.isStringLiteralLike(node)) {
+    return node.text;
+  }
+  if (ts.isNoSubstitutionTemplateLiteral(node)) {
+    return node.text;
+  }
+  if (ts.isTemplateExpression(node) && node.templateSpans.length === 0) {
+    return node.head.text;
+  }
+  return null;
+}
+
+function extractStaticNumber(node: ts.Expression): number | null {
+  if (ts.isNumericLiteral(node)) {
+    const value = Number(node.text);
+    return Number.isFinite(value) ? value : null;
+  }
+  return null;
+}
+
+function collectTagsFromExpression(target: ts.Expression, into: Set<string>) {
+  if (ts.isArrayLiteralExpression(target)) {
+    for (const element of target.elements) {
+      if (!ts.isExpression(element)) {
+        continue;
+      }
+      const value = extractStaticString(element);
+      if (value && !value.startsWith('_N_')) {
+        into.add(value);
+      }
+    }
+    return;
+  }
+
+  const literal = extractStaticString(target);
+  if (literal) {
+    literal
+      .split(/[,\n]/)
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0 && !entry.startsWith('_N_'))
+      .forEach((entry) => {
+        into.add(entry);
+      });
+  }
+}
+
+function collectCacheFromObjectLiteral(
+  node: ts.ObjectLiteralExpression,
+  metadata: FileCacheMetadata
+) {
+  for (const property of node.properties) {
+    if (!ts.isPropertyAssignment(property) || !property.name) {
+      continue;
+    }
+
+    const name = ts.isIdentifier(property.name)
+      ? property.name.text
+      : ts.isStringLiteralLike(property.name)
+        ? property.name.text
+        : undefined;
+
+    if (!name) {
+      continue;
+    }
+
+    if (!ts.isExpression(property.initializer)) {
+      continue;
+    }
+
+    switch (name) {
+      case 'cache': {
+        const literal = extractStaticString(property.initializer);
+        if (literal && CACHE_LITERAL_VALUES.has(literal as 'force-cache' | 'no-store')) {
+          metadata.cacheModes.add(literal as 'force-cache' | 'no-store');
+        }
+        break;
+      }
+      case 'revalidate': {
+        if (property.initializer.kind === ts.SyntaxKind.FalseKeyword) {
+          metadata.hasRevalidateFalse = true;
+        } else {
+          const value = extractStaticNumber(property.initializer);
+          if (typeof value === 'number') {
+            metadata.revalidateSeconds.add(value);
+          }
+        }
+        break;
+      }
+      case 'next': {
+        if (ts.isObjectLiteralExpression(property.initializer)) {
+          collectCacheFromObjectLiteral(property.initializer, metadata);
+        }
+        break;
+      }
+      case 'tags': {
+        collectTagsFromExpression(property.initializer, metadata.tags);
+        break;
+      }
+      case 'headers': {
+        if (ts.isObjectLiteralExpression(property.initializer)) {
+          collectCacheFromObjectLiteral(property.initializer, metadata);
+        }
+        break;
+      }
+      case 'x-next-cache-tags': {
+        collectTagsFromExpression(property.initializer, metadata.tags);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+}
+
+function isIdentifierWithName(node: ts.Expression, name: string): boolean {
+  if (ts.isIdentifier(node)) {
+    return node.text === name;
+  }
+  if (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.name)) {
+    return node.name.text === name;
+  }
+  return false;
+}
+
+export function collectCacheMetadata({ sourceText }: CollectOptions): FileCacheMetadata {
+  const metadata = createEmptyMetadata();
+  const sourceFile = ts.createSourceFile(
+    'inline.tsx',
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  );
+
+  const visit = (node: ts.Node) => {
+    if (ts.isCallExpression(node)) {
+      if (isIdentifierWithName(node.expression, 'fetch') && node.arguments.length >= 2) {
+        const options = node.arguments[1];
+        if (ts.isObjectLiteralExpression(options)) {
+          collectCacheFromObjectLiteral(options, metadata);
+        }
+      } else if (isIdentifierWithName(node.expression, 'revalidateTag')) {
+        const [first] = node.arguments;
+        if (first && ts.isExpression(first)) {
+          const tag = extractStaticString(first);
+          if (tag) {
+            metadata.revalidateTagCalls.add(tag);
+          }
+        }
+      } else if (isIdentifierWithName(node.expression, 'revalidatePath')) {
+        const [first] = node.arguments;
+        if (first && ts.isExpression(first)) {
+          const path = extractStaticString(first);
+          if (path) {
+            metadata.revalidatePathCalls.add(path);
+          }
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return metadata;
+}

--- a/packages/analyzer/src/types/next-manifest.ts
+++ b/packages/analyzer/src/types/next-manifest.ts
@@ -1,3 +1,5 @@
+import type { RouteCacheMetadata } from '@server-client-xray/schemas';
+
 export interface NextBuildManifest {
   pages: Record<string, string[]>;
   app: Record<string, string[]>;
@@ -16,6 +18,7 @@ export interface ParsedRouteAsset {
   route: string;
   chunks: string[];
   totalBytes?: number;
+  cache?: RouteCacheMetadata;
 }
 
 export interface ParsedManifests {

--- a/packages/schemas/src/model.schema.json
+++ b/packages/schemas/src/model.schema.json
@@ -69,7 +69,9 @@
         "tags": {
           "type": "array",
           "items": { "type": "string", "minLength": 1 }
-        }
+        },
+        "cache": { "$ref": "#/definitions/NodeCacheMetadata" },
+        "mutations": { "$ref": "#/definitions/NodeMutationMetadata" }
       }
     },
     "RouteEntry": {
@@ -84,7 +86,8 @@
           "type": "array",
           "items": { "type": "string", "minLength": 1 }
         },
-        "totalBytes": { "type": "number", "minimum": 0 }
+        "totalBytes": { "type": "number", "minimum": 0 },
+        "cache": { "$ref": "#/definitions/RouteCacheMetadata" }
       }
     },
     "BuildInfo": {
@@ -135,6 +138,51 @@
             "line": { "type": "integer", "minimum": 0 },
             "col": { "type": "integer", "minimum": 0 }
           }
+        }
+      }
+    },
+    "NodeCacheMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "modes": {
+          "type": "array",
+          "items": { "enum": ["force-cache", "no-store"] }
+        },
+        "revalidateSeconds": {
+          "type": "array",
+          "items": { "type": "number", "minimum": 0 }
+        },
+        "hasRevalidateFalse": { "type": "boolean" }
+      }
+    },
+    "NodeMutationMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "paths": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "RouteCacheMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "revalidateSeconds": {
+          "oneOf": [
+            { "type": "number", "minimum": 0 },
+            { "type": "boolean", "enum": [false] }
+          ]
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
         }
       }
     }

--- a/packages/schemas/src/types.ts
+++ b/packages/schemas/src/types.ts
@@ -31,6 +31,8 @@ export interface XNode {
   suggestions?: Suggestion[];
   children?: string[];
   tags?: string[];
+  cache?: NodeCacheMetadata;
+  mutations?: NodeMutationMetadata;
 }
 
 export interface RouteEntry {
@@ -39,6 +41,7 @@ export interface RouteEntry {
   changedAt?: string;
   chunks?: string[];
   totalBytes?: number;
+  cache?: RouteCacheMetadata;
 }
 
 export interface BuildInfo {
@@ -63,4 +66,20 @@ export interface Model {
   nodes: Record<string, XNode>;
   build: BuildInfo;
   flight?: FlightData;
+}
+
+export interface NodeCacheMetadata {
+  modes?: Array<'force-cache' | 'no-store'>;
+  revalidateSeconds?: number[];
+  hasRevalidateFalse?: boolean;
+}
+
+export interface NodeMutationMetadata {
+  tags?: string[];
+  paths?: string[];
+}
+
+export interface RouteCacheMetadata {
+  revalidateSeconds?: number | false;
+  tags?: string[];
 }


### PR DESCRIPTION
## Summary
- capture Next.js cache metadata (tags, revalidate settings) in analyzer nodes and routes
- extract fetch/revalidate hints during graph build to power the cache lens
- update the schema and tests so cache lens consumers receive the enriched data

Closes #47

## Testing
- pnpm -r test
- pnpm -r build
