### PR TITLE
chore: update repository URLs after org rename

### DIFF
--- a/packages/analyzer/package.json
+++ b/packages/analyzer/package.json
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/server-client-xray/rsc-xray"
+    "url": "https://github.com/rsc-xray/rsc-xray"
   },
   "license": "MIT"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/server-client-xray/rsc-xray"
+    "url": "https://github.com/rsc-xray/rsc-xray"
   },
   "license": "MIT"
 }

--- a/packages/hydration/package.json
+++ b/packages/hydration/package.json
@@ -34,7 +34,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/server-client-xray/rsc-xray"
+    "url": "https://github.com/rsc-xray/rsc-xray"
   },
   "license": "MIT"
 }

--- a/packages/report-html/package.json
+++ b/packages/report-html/package.json
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/server-client-xray/rsc-xray"
+    "url": "https://github.com/rsc-xray/rsc-xray"
   },
   "license": "MIT"
 }

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/server-client-xray/rsc-xray"
+    "url": "https://github.com/rsc-xray/rsc-xray"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- point package repository URLs to the renamed GitHub org (rsc-xray)

## Testing
- pnpm format:check
