### PR TITLE
feat: add flight tap production support

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -18,10 +18,13 @@ This document threads the core OSS flows into repeatable checklists so you can r
 2. From the repo root, stream the route you want to inspect:
 
    ```bash
-   pnpm -F @rsc-xray/cli flight-tap --url http://localhost:3000/products/analyzer --out ./flight.json
+   pnpm -F @rsc-xray/cli flight-tap \
+     --url http://localhost:3000/(shop)/products/1 \
+     --route /products/[id] \
+     --out examples/next-app/.scx/flight.json
    ```
 
-3. The command writes human-readable chunk timings to STDOUT and saves the sampled data when `--out` is provided. Use these samples to align overlay observations with Flight delivery order.
+3. The command writes chunk timings to STDOUT and saves a model-compatible snapshot (`{ "samples": [...] }`) when `--out` is provided. Analyzer runs fold this data into `model.flight`, enabling the Pro overlay to surface timeline summaries.
 
 ## Overlay Stub Behavior
 

--- a/examples/next-app/package.json
+++ b/examples/next-app/package.json
@@ -7,6 +7,7 @@
     "start": "next start",
     "lint": "next lint",
     "test:hydration": "playwright test tests/hydration.spec.ts",
+    "test:flight": "playwright test tests/flightTap.spec.ts",
     "test:lighthouse": "pnpm exec tsx scripts/runLighthouse.ts"
   },
   "dependencies": {

--- a/examples/next-app/tests/flightTap.spec.ts
+++ b/examples/next-app/tests/flightTap.spec.ts
@@ -1,0 +1,85 @@
+import { spawn } from 'node:child_process';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
+import { pathToFileURL } from 'node:url';
+
+import { expect, test } from '@playwright/test';
+import treeKill from 'tree-kill';
+
+import { getAvailablePort } from './utils/getAvailablePort';
+import { waitForPort } from './utils/waitForPort';
+
+const HOST = '127.0.0.1';
+const exampleRoot = path.resolve(__dirname, '..');
+const snapshotPath = path.join(exampleRoot, '.scx', 'flight.json');
+const cliModuleUrl = pathToFileURL(
+  path.resolve(exampleRoot, '..', '..', 'packages', 'cli', 'dist', 'index.js')
+).href;
+
+async function resolveFlightTap() {
+  try {
+    const mod = await import('@rsc-xray/cli');
+    return mod.flightTap;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ERR_MODULE_NOT_FOUND') {
+      throw error;
+    }
+    const mod = await import(cliModuleUrl);
+    return mod.flightTap;
+  }
+}
+
+async function stopServer(child: ReturnType<typeof spawn> | undefined) {
+  if (!child?.pid) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    treeKill(child.pid!, 'SIGTERM', (error) => {
+      if (error && (error as NodeJS.ErrnoException).code !== 'ESRCH') {
+        console.warn('[scx] Failed to terminate Next dev server cleanly', error);
+      }
+      resolve();
+    });
+  });
+}
+
+test.describe('flight tap telemetry', () => {
+  let server: ReturnType<typeof spawn> | undefined;
+  let port: number;
+  let flightTap: (typeof import('@rsc-xray/cli'))['flightTap'];
+
+  test.beforeAll(async () => {
+    flightTap = await resolveFlightTap();
+    await rm(snapshotPath, { force: true });
+    port = await getAvailablePort();
+    server = spawn('pnpm', ['dev', '--hostname', HOST, '--port', String(port)], {
+      cwd: exampleRoot,
+      env: { ...process.env, PORT: String(port) },
+      stdio: 'inherit',
+    });
+    await waitForPort({ port, host: HOST });
+  });
+
+  test.afterAll(async () => {
+    await stopServer(server);
+    server = undefined;
+  });
+
+  test('captures flight samples for streaming route', async () => {
+    const result = await flightTap({
+      url: `http://${HOST}:${port}/products/1`,
+      route: '/products/[id]',
+      output: new PassThrough(),
+    });
+
+    expect(result.samples.length).toBeGreaterThan(0);
+
+    await mkdir(path.dirname(snapshotPath), { recursive: true });
+    await writeFile(snapshotPath, JSON.stringify({ samples: result.samples }, null, 2), 'utf8');
+
+    const raw = await readFile(snapshotPath, 'utf8');
+    const parsed = JSON.parse(raw) as { samples?: unknown };
+    expect(Array.isArray(parsed.samples)).toBe(true);
+  });
+});

--- a/examples/next-app/tsconfig.json
+++ b/examples/next-app/tsconfig.json
@@ -15,7 +15,8 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@rsc-xray/hydration": ["../../packages/hydration/src/index.ts"]
+      "@rsc-xray/hydration": ["../../packages/hydration/src/index.ts"],
+      "@rsc-xray/cli": ["../../packages/cli/src/index.ts"]
     },
     "plugins": [
       {


### PR DESCRIPTION
Closes rsc-xray/rsc-xray-pro#73

## Summary
- teach the CLI flight tap to annotate chunk output with route metadata and write a model-compatible snapshot
- load .scx/flight.json into the analyzer and refresh docs/tests for the new Flight timeline contract
- add a Playwright smoke test that captures streaming routes via dynamic import to support the ESM CLI build

## Testing
- pnpm --filter @rsc-xray/example-next-app test:flight
- pnpm -r test
- pnpm -r build
