### PR TITLE
Harden flight tap timeout and snapshot error handling

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -38,6 +38,8 @@ Sample output:
 
 Use the captured timings to correlate overlay observations with Flight delivery order.
 
+- The `--timeout <ms>` flag aborts the capture if a stream hangs (defaults to 30000). Set `--timeout 0` to disable the guard when debugging long-running routes.
+
 ## Overlay Stub
 
 - The OSS demo ships a stub overlay that logs instructions until `@rsc-xray/pro-overlay` is installed.

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -21,10 +21,11 @@ This document threads the core OSS flows into repeatable checklists so you can r
    pnpm -F @rsc-xray/cli flight-tap \
      --url http://localhost:3000/(shop)/products/1 \
      --route /products/[id] \
-     --out examples/next-app/.scx/flight.json
+     --out examples/next-app/.scx/flight.json \
+     --timeout 30000
    ```
 
-3. The command writes chunk timings to STDOUT and saves a model-compatible snapshot (`{ "samples": [...] }`) when `--out` is provided. Analyzer runs fold this data into `model.flight`, enabling the Pro overlay to surface timeline summaries.
+3. The command writes chunk timings to STDOUT and saves a model-compatible snapshot (`{ "samples": [...] }`) when `--out` is provided. Analyzer runs fold this data into `model.flight`, enabling the Pro overlay to surface timeline summaries. Use `--timeout <ms>` to raise/lower the default 30s guard (set `0` to disable).
 
 ## Overlay Stub Behavior
 

--- a/packages/analyzer/src/lib/__tests__/snapshots.test.ts
+++ b/packages/analyzer/src/lib/__tests__/snapshots.test.ts
@@ -1,0 +1,43 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { readFlightSnapshot, readHydrationSnapshot } from '../snapshots';
+
+describe('snapshot readers', () => {
+  async function withTempDir(run: (dir: string) => Promise<void>) {
+    const dir = await mkdtemp(join(tmpdir(), 'scx-snapshots-'));
+    try {
+      await run(dir);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+
+  it('returns an empty object when hydration snapshot is missing', async () => {
+    await withTempDir(async (dir) => {
+      const result = await readHydrationSnapshot(dir);
+      expect(result).toEqual({});
+    });
+  });
+
+  it('throws when hydration snapshot cannot be parsed', async () => {
+    await withTempDir(async (dir) => {
+      const targetDir = join(dir, '.scx');
+      await mkdir(targetDir, { recursive: true });
+      await writeFile(join(targetDir, 'hydration.json'), '{ invalid', 'utf8');
+      await expect(readHydrationSnapshot(dir)).rejects.toThrow(/Failed to read hydration snapshot/);
+    });
+  });
+
+  it('throws when flight snapshot json is invalid', async () => {
+    await withTempDir(async (dir) => {
+      const targetDir = join(dir, '.scx');
+      await mkdir(targetDir, { recursive: true });
+      await writeFile(join(targetDir, 'flight.json'), '{ invalid', 'utf8');
+      await expect(readFlightSnapshot(dir)).rejects.toThrow(/Failed to read Flight snapshot/);
+    });
+  });
+});

--- a/packages/analyzer/src/lib/snapshots.ts
+++ b/packages/analyzer/src/lib/snapshots.ts
@@ -1,0 +1,85 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import type { FlightSample } from '@rsc-xray/schemas';
+
+export const HYDRATION_SNAPSHOT_PATH = ['.scx', 'hydration.json'] as const;
+export const FLIGHT_SNAPSHOT_PATH = ['.scx', 'flight.json'] as const;
+
+export async function readHydrationSnapshot(projectRoot: string): Promise<Record<string, number>> {
+  const snapshotPath = join(projectRoot, ...HYDRATION_SNAPSHOT_PATH);
+  try {
+    const raw = await readFile(snapshotPath, 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') {
+      return {};
+    }
+
+    const durations: Record<string, number> = {};
+    for (const [nodeId, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof nodeId !== 'string' || nodeId.length === 0) {
+        continue;
+      }
+      const numeric = typeof value === 'number' ? value : Number(value);
+      if (Number.isFinite(numeric) && numeric >= 0) {
+        durations[nodeId] = numeric;
+      }
+    }
+    return durations;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {};
+    }
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read hydration snapshot at ${snapshotPath}: ${reason}`);
+  }
+}
+
+export async function readFlightSnapshot(projectRoot: string): Promise<FlightSample[]> {
+  const snapshotPath = join(projectRoot, ...FLIGHT_SNAPSHOT_PATH);
+  try {
+    const raw = await readFile(snapshotPath, 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') {
+      return [];
+    }
+
+    const samplesInput = (parsed as { samples?: unknown }).samples;
+    if (!Array.isArray(samplesInput)) {
+      return [];
+    }
+
+    const samples: FlightSample[] = [];
+    for (const entry of samplesInput) {
+      if (!entry || typeof entry !== 'object') {
+        continue;
+      }
+      const { route, ts, chunkIndex, label } = entry as Record<string, unknown>;
+      if (typeof route !== 'string' || route.trim().length === 0) {
+        continue;
+      }
+      const tsNumber = typeof ts === 'number' ? ts : Number(ts);
+      const chunkNumber = typeof chunkIndex === 'number' ? chunkIndex : Number(chunkIndex);
+      if (!Number.isFinite(tsNumber) || !Number.isFinite(chunkNumber)) {
+        continue;
+      }
+      const chunk = Math.max(0, Math.trunc(chunkNumber));
+      const sample: FlightSample = {
+        route,
+        ts: tsNumber,
+        chunkIndex: chunk,
+      };
+      if (typeof label === 'string' && label.trim().length > 0) {
+        sample.label = label;
+      }
+      samples.push(sample);
+    }
+    return samples;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return [];
+    }
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read Flight snapshot at ${snapshotPath}: ${reason}`);
+  }
+}


### PR DESCRIPTION
## Summary
- add a default 30s timeout to the CLI flight tap with a `--timeout` override and coverage to prevent hung captures (closes #63)
- surface non-ENOENT hydration/Flight snapshot read failures via explicit errors and add unit tests for malformed inputs (closes #64)
- document the new timeout flag in the Quickstart and workflow guide

## Testing
- pnpm -r test
- pnpm -r lint
- pnpm -r build
