### PR TITLE
Add package README guides

### DIFF
--- a/examples/next-app/README.md
+++ b/examples/next-app/README.md
@@ -1,0 +1,33 @@
+# rsc-xray Example App
+
+Mini Next.js App Router project used to exercise the analyzer, CLI flows, and overlay demos.
+
+## What it showcases
+
+- Baseline product listing with nested Suspense boundaries.
+- Intentional waterfall and forbidden-import scenarios for analyzer smoke tests.
+- Instrumented client components that emit hydration timings.
+
+## Step-by-step usage
+
+1. Install dependencies at the repo root:
+   ```bash
+   corepack pnpm install
+   ```
+2. Build the example (generates `.next` artifacts for the analyzer):
+   ```bash
+   pnpm -C examples/next-app build
+   ```
+3. Run the dev server to explore scenarios or capture Flight streams:
+   ```bash
+   pnpm -C examples/next-app dev
+   ```
+4. Use the CLI from the repo root to analyze/report:
+   ```bash
+   pnpm -F @rsc-xray/cli analyze --project ./examples/next-app --out ./model.json
+   pnpm -F @rsc-xray/cli report --model ./model.json --out ./report.html
+   ```
+
+## Tests
+
+Playwright/CLI telemetry scripts in the Pro repo depend on this app, while OSS unit tests run against its compiled output. Keep the fixtures tidy so analyzer snapshots remain actionable.

--- a/packages/analyzer/README.md
+++ b/packages/analyzer/README.md
@@ -1,0 +1,59 @@
+# @rsc-xray/analyzer
+
+Static analyzer that inspects a Next.js App Router build and produces the shared `model.json` contract consumed by the OSS report, Pro overlay, and CI automations.
+
+## What it solves
+
+- Classifies every node under the App Router as server, client, suspense, or route boundary.
+- Attributes client bundle bytes to the components that load them.
+- Detects forbidden client imports and sequential server awaits so teams can fix waterfalls quickly.
+- Folds hydration durations and Flight samples (when available) into the model for richer tooling downstream.
+
+## Installation
+
+```bash
+pnpm add -D @rsc-xray/analyzer
+```
+
+## Step-by-step usage (Node API)
+
+1. Build your Next.js project so `.next` manifests exist:
+   ```bash
+   pnpm next build
+   ```
+2. Call `analyzeProject` from a script or workspace tool:
+
+   ```ts
+   import { analyzeProject } from '@rsc-xray/analyzer';
+
+   const model = await analyzeProject({
+     projectRoot: '/path/to/app',
+     distDir: '.next',
+     appDir: 'app',
+   });
+
+   await fs.promises.writeFile('model.json', JSON.stringify(model, null, 2));
+   ```
+
+3. Pass `model.json` to the CLI report generator or the Pro overlay.
+
+## Step-by-step usage (via CLI)
+
+Rather use the ready-made executable? Combine this package with the CLI:
+
+```bash
+pnpm -F @rsc-xray/cli analyze --project ./examples/next-app --out ./model.json
+```
+
+The CLI delegates to `@rsc-xray/analyzer`, validates the schema, and writes the model safely.
+
+## Tests
+
+- `packages/analyzer/src/lib/__tests__/analyzeProject.test.ts` covers the end-to-end pipeline against fixture projects.
+- `packages/analyzer/src/lib/__tests__/snapshots.test.ts` guarantees hydration/Flight snapshots behave exactly as described above.
+
+Run the analyzer suite with:
+
+```bash
+pnpm -F @rsc-xray/analyzer test -- --run
+```

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,61 @@
+# @rsc-xray/cli
+
+Command-line wrapper for the rsc-xray analyzer, report generator, and Flight tap capture workflow.
+
+## What it solves
+
+- Produces `model.json` from a Next.js App Router project with one command.
+- Generates a fully offline HTML report for sharing analyzer findings.
+- Streams React Flight chunks so you can understand suspense delivery order and chunk sizes.
+
+## Installation
+
+```bash
+pnpm add -D @rsc-xray/cli
+```
+
+## Step-by-step usage
+
+1. **Prepare your project**
+   ```bash
+   pnpm next build
+   ```
+2. **Generate the model**
+
+   ```bash
+   pnpm -F @rsc-xray/cli analyze --project ./examples/next-app --out ./model.json
+   ```
+
+   - Validates the analyzer output against the shared JSON schema.
+   - Overwrites the target file only when validation succeeds.
+
+3. **Create the HTML report**
+
+   ```bash
+   pnpm -F @rsc-xray/cli report --model ./model.json --out ./report.html
+   ```
+
+   - Produces a static report you can open locally or upload as a CI artifact.
+
+4. **(Optional) Capture Flight streaming data**
+
+   ```bash
+   pnpm -C examples/next-app dev &
+   pnpm -F @rsc-xray/cli flight-tap      --url http://localhost:3000/products/1      --route /products/[id]      --out ./.scx/flight.json      --timeout 30000
+   ```
+
+   - The timeout guard aborts hung streams; pass `--timeout 0` to disable it when debugging slower routes.
+
+## Tests
+
+Command behavior is covered by:
+
+- `packages/cli/src/commands/__tests__/analyze.test.ts`
+- `packages/cli/src/commands/__tests__/report.test.ts`
+- `packages/cli/src/commands/__tests__/flightTap.test.ts`
+
+Run the suite with:
+
+```bash
+pnpm -F @rsc-xray/cli test -- --run
+```

--- a/packages/hydration/README.md
+++ b/packages/hydration/README.md
@@ -1,0 +1,63 @@
+# @rsc-xray/hydration
+
+Tiny helper library that records hydration timings for client components and exposes a hook that plugs into React.
+
+## What it solves
+
+- Marks hydration start/end for each island using the Performance API.
+- Provides a React hook (`createHydrationHook`) that instruments components with minimal boilerplate.
+- Returns aggregated timings so the analyzer and overlay can display hydration costs per route.
+
+## Installation
+
+```bash
+pnpm add @rsc-xray/hydration
+```
+
+## Step-by-step usage
+
+1. **Create the hook once**
+
+   ```ts
+   import { createHydrationHook } from '@rsc-xray/hydration';
+   import { useEffect, useRef } from 'react';
+
+   export const useHydrationTimings = createHydrationHook({ useEffect, useRef });
+   ```
+
+2. **Instrument client components**
+
+   ```tsx
+   'use client';
+   import { useHydrationTimings } from './hooks/useHydrationTimings';
+
+   export function ProductGrid() {
+     useHydrationTimings('product-grid');
+     return <div>...</div>;
+   }
+   ```
+
+3. **Read timings when needed**
+
+   ```ts
+   import { getHydrationDurations } from '@rsc-xray/hydration';
+
+   const durations = getHydrationDurations();
+   console.log(durations['product-grid']);
+   ```
+
+4. **Reset between navigations/tests**
+   ```ts
+   import { resetHydrationMetrics } from '@rsc-xray/hydration';
+   resetHydrationMetrics();
+   ```
+
+## Tests
+
+- `packages/hydration/src/__tests__/hydration.test.tsx` verifies the hook API and timing collection end-to-end, mirroring the steps above.
+
+Run the suite with:
+
+```bash
+pnpm -F @rsc-xray/hydration test -- --run
+```

--- a/packages/report-html/README.md
+++ b/packages/report-html/README.md
@@ -1,0 +1,47 @@
+# @rsc-xray/report-html
+
+HTML renderer for the `model.json` contract produced by the analyzer. Generates a static, shareable report without any server dependency.
+
+## What it solves
+
+- Converts analyzer output into an interactive HTML artifact that teams can open locally or publish from CI.
+- Highlights server/client boundaries, Suspense nodes, bytes per island, diagnostics, and suggestions.
+- Ships as an ESM module so it can run in Node or bundle into other tooling.
+
+## Installation
+
+```bash
+pnpm add -D @rsc-xray/report-html
+```
+
+## Step-by-step usage
+
+1. Generate `model.json` using the CLI or analyzer API.
+2. Render the report:
+
+   ```ts
+   import { renderReport } from '@rsc-xray/report-html';
+   import fs from 'node:fs/promises';
+
+   const model = JSON.parse(await fs.readFile('model.json', 'utf8'));
+   const html = renderReport({ model });
+   await fs.writeFile('report.html', html, 'utf8');
+   ```
+
+3. Open `report.html` in any browser or upload it as a CI artifact.
+
+Prefer the CLI? Run:
+
+```bash
+pnpm -F @rsc-xray/cli report --model ./model.json --out ./report.html
+```
+
+## Tests
+
+- `packages/report-html/src/__tests__/renderReport.test.ts` snapshots the generated HTML to guarantee parity with the documented workflow.
+
+Run the suite with:
+
+```bash
+pnpm -F @rsc-xray/report-html test -- --run
+```

--- a/packages/schemas/README.md
+++ b/packages/schemas/README.md
@@ -1,0 +1,51 @@
+# @rsc-xray/schemas
+
+Shared TypeScript types and JSON schema that define the `model.json` contract between the analyzer, CLI, HTML report, and Pro tooling.
+
+## What it solves
+
+- Provides canonical TypeScript types (`Model`, `XNode`, etc.) so packages can share a single source of truth.
+- Exposes a JSON schema suitable for runtime validation (used by the CLI and CI workflows).
+- Keeps the OSS analyzer and Pro overlay in lockstep when the model evolves.
+
+## Installation
+
+```bash
+pnpm add -D @rsc-xray/schemas
+```
+
+## Step-by-step usage
+
+1. **Import the types** where you consume `model.json`:
+
+   ```ts
+   import type { Model } from '@rsc-xray/schemas';
+
+   const model: Model = JSON.parse(await fs.promises.readFile('model.json', 'utf8'));
+   ```
+
+2. **Validate at runtime** (optional but recommended):
+
+   ```ts
+   import Ajv from 'ajv';
+   import { modelSchema } from '@rsc-xray/schemas';
+
+   const ajv = new Ajv({ allErrors: true });
+   const validate = ajv.compile(modelSchema);
+   if (!validate(model)) {
+     throw new Error(ajv.errorsText(validate.errors));
+   }
+   ```
+
+3. **Sync with the CLI/analyzer** — both rely on this package, so your code stays compatible as long as you import the same version.
+
+## Tests
+
+- `packages/cli/src/commands/__tests__/analyze.test.ts` and `packages/cli/src/commands/__tests__/report.test.ts` validate models against this schema.
+- `packages/schemas/src/index.test.ts` snapshots the exported schema to prevent accidental breaking changes.
+
+Run the schema tests with:
+
+```bash
+pnpm -F @rsc-xray/schemas test -- --run
+```


### PR DESCRIPTION
## Summary
- add README files for the analyzer, CLI, hydration helpers, report renderer, schemas, and example app with clear descriptions and step-by-step usage
- cross-link each README to the automated tests that cover the documented workflows

## Testing
- pnpm -r test
- pnpm -r lint
- pnpm -r build

Closes #66
