### PR TITLE
docs(OSS): README badges + keywords; prepare patch release (Closes #69)

### DIFF
--- a/.changeset/oss-readme-badges-and-keywords.md
+++ b/.changeset/oss-readme-badges-and-keywords.md
@@ -1,0 +1,9 @@
+---
+'@rsc-xray/analyzer': patch
+'@rsc-xray/cli': patch
+'@rsc-xray/schemas': patch
+'@rsc-xray/report-html': patch
+'@rsc-xray/hydration': patch
+---
+
+chore(docs): add npm badges to package READMEs and keywords to manifests for improved discovery; include updated README content in published tarballs.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# rsc-xray (OSS)
+# RSC X‑Ray — Next.js RSC analyzer & report
 
-Core analyzer + CLI + schemas + offline HTML report.
+[![npm](https://img.shields.io/npm/v/@rsc-xray/cli.svg)](https://www.npmjs.com/package/@rsc-xray/cli)
+[![CI](https://img.shields.io/github/actions/workflow/status/rsc-xray/rsc-xray/ci.yml?branch=main)](https://github.com/rsc-xray/rsc-xray/actions)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+Analyze React Server Components in Next.js: boundaries, Suspense, bundle bytes, and suggestions — export a shareable offline HTML report.
 
 ## Features (Free/OSS)
 
@@ -65,7 +69,16 @@ STDOUT prints chunk timings; the optional `--out` flag stores the samples for la
 - Toggle with **Control**+Shift+X or run `window.__SCX_OVERLAY__?.toggle()` in the browser console.
 - Install `@rsc-xray/pro-overlay` in the example app to unlock the full UI (hydration timings, cache lens, CI budgets).
 
-## Pro & Team
+### RSC X‑Ray Pro
 
-Interested in overlay UI, hydration timings, cache lens, CI dashboards, or licensing flows?  
-See **[rsc-xray-pro](https://github.com/rsc-xray/rsc-xray-pro)**.
+Paid plans available — unlock the full toolkit:
+
+- Overlay UI — live boundary tree, Suspense markers, bundle bytes, hydration timings
+- Flight tap & timeline — capture React Flight streaming; visualize chunk order, sizes, labels
+- Cache lens — inspect `tags`, revalidate policies, and route impact
+- Waterfall detector — find sequential awaits; guided fixes (preload/parallelize)
+- Codemods — `use client`, wrap with Suspense, add preload/hydration hook
+- VS Code extension — analyzer diagnostics + “Open in XRay” deep links
+- CI budgets & trends — PR comments, thresholds, and historical deltas
+
+Learn more → https://rsc-xray.dev • Pricing → https://rsc-xray.dev/pricing

--- a/packages/analyzer/README.md
+++ b/packages/analyzer/README.md
@@ -1,5 +1,8 @@
 # @rsc-xray/analyzer
 
+[![npm](https://img.shields.io/npm/v/@rsc-xray/analyzer.svg)](https://www.npmjs.com/package/@rsc-xray/analyzer)
+[![Downloads](https://img.shields.io/npm/dm/@rsc-xray/analyzer.svg)](https://www.npmjs.com/package/@rsc-xray/analyzer)
+
 Static analyzer that inspects a Next.js App Router build and produces the shared `model.json` contract consumed by the OSS report, Pro overlay, and CI automations.
 
 ## What it solves
@@ -57,3 +60,17 @@ Run the analyzer suite with:
 ```bash
 pnpm -F @rsc-xray/analyzer test -- --run
 ```
+
+### RSC X‑Ray Pro
+
+Paid plans available — unlock the full toolkit:
+
+- Overlay UI — live boundary tree, Suspense markers, bundle bytes, hydration timings
+- Flight tap & timeline — capture React Flight streaming; visualize chunk order, sizes, labels
+- Cache lens — inspect `tags`, revalidate policies, and route impact
+- Waterfall detector — find sequential awaits; guided fixes (preload/parallelize)
+- Codemods — `use client`, wrap with Suspense, add preload/hydration hook
+- VS Code extension — analyzer diagnostics + “Open in XRay” deep links
+- CI budgets & trends — PR comments, thresholds, and historical deltas
+
+Learn more → https://rsc-xray.dev • Pricing → https://rsc-xray.dev/pricing

--- a/packages/analyzer/package.json
+++ b/packages/analyzer/package.json
@@ -4,6 +4,17 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "keywords": [
+    "react-server-components",
+    "rsc",
+    "nextjs",
+    "debug",
+    "observability",
+    "static-analysis",
+    "suspense",
+    "bundles",
+    "bytes"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,5 +1,8 @@
 # @rsc-xray/cli
 
+[![npm](https://img.shields.io/npm/v/@rsc-xray/cli.svg)](https://www.npmjs.com/package/@rsc-xray/cli)
+[![Downloads](https://img.shields.io/npm/dm/@rsc-xray/cli.svg)](https://www.npmjs.com/package/@rsc-xray/cli)
+
 Command-line wrapper for the rsc-xray analyzer, report generator, and Flight tap capture workflow.
 
 ## What it solves
@@ -59,3 +62,17 @@ Run the suite with:
 ```bash
 pnpm -F @rsc-xray/cli test -- --run
 ```
+
+### RSC X‑Ray Pro
+
+Paid plans available — unlock the full toolkit:
+
+- Overlay UI — live boundary tree, Suspense markers, bundle bytes, hydration timings
+- Flight tap & timeline — capture React Flight streaming; visualize chunk order, sizes, labels
+- Cache lens — inspect `tags`, revalidate policies, and route impact
+- Waterfall detector — find sequential awaits; guided fixes (preload/parallelize)
+- Codemods — `use client`, wrap with Suspense, add preload/hydration hook
+- VS Code extension — analyzer diagnostics + “Open in XRay” deep links
+- CI budgets & trends — PR comments, thresholds, and historical deltas
+
+Learn more → https://rsc-xray.dev • Pricing → https://rsc-xray.dev/pricing

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,6 +4,16 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "keywords": [
+    "react-server-components",
+    "rsc",
+    "nextjs",
+    "debug",
+    "observability",
+    "cli",
+    "report",
+    "analyze"
+  ],
   "scripts": {
     "build": "tsc -b",
     "test": "vitest --run --passWithNoTests",

--- a/packages/hydration/README.md
+++ b/packages/hydration/README.md
@@ -1,5 +1,8 @@
 # @rsc-xray/hydration
 
+[![npm](https://img.shields.io/npm/v/@rsc-xray/hydration.svg)](https://www.npmjs.com/package/@rsc-xray/hydration)
+[![Downloads](https://img.shields.io/npm/dm/@rsc-xray/hydration.svg)](https://www.npmjs.com/package/@rsc-xray/hydration)
+
 Tiny helper library that records hydration timings for client components and exposes a hook that plugs into React.
 
 ## What it solves
@@ -61,3 +64,17 @@ Run the suite with:
 ```bash
 pnpm -F @rsc-xray/hydration test -- --run
 ```
+
+### RSC X‑Ray Pro
+
+Paid plans available — unlock the full toolkit:
+
+- Overlay UI — live boundary tree, Suspense markers, bundle bytes, hydration timings
+- Flight tap & timeline — capture React Flight streaming; visualize chunk order, sizes, labels
+- Cache lens — inspect `tags`, revalidate policies, and route impact
+- Waterfall detector — find sequential awaits; guided fixes (preload/parallelize)
+- Codemods — `use client`, wrap with Suspense, add preload/hydration hook
+- VS Code extension — analyzer diagnostics + “Open in XRay” deep links
+- CI budgets & trends — PR comments, thresholds, and historical deltas
+
+Learn more → https://rsc-xray.dev • Pricing → https://rsc-xray.dev/pricing

--- a/packages/hydration/package.json
+++ b/packages/hydration/package.json
@@ -4,6 +4,16 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "keywords": [
+    "react-server-components",
+    "rsc",
+    "nextjs",
+    "debug",
+    "observability",
+    "hydration",
+    "performance",
+    "timings"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/report-html/README.md
+++ b/packages/report-html/README.md
@@ -1,5 +1,8 @@
 # @rsc-xray/report-html
 
+[![npm](https://img.shields.io/npm/v/@rsc-xray/report-html.svg)](https://www.npmjs.com/package/@rsc-xray/report-html)
+[![Downloads](https://img.shields.io/npm/dm/@rsc-xray/report-html.svg)](https://www.npmjs.com/package/@rsc-xray/report-html)
+
 HTML renderer for the `model.json` contract produced by the analyzer. Generates a static, shareable report without any server dependency.
 
 ## What it solves
@@ -45,3 +48,17 @@ Run the suite with:
 ```bash
 pnpm -F @rsc-xray/report-html test -- --run
 ```
+
+### RSC X‑Ray Pro
+
+Paid plans available — unlock the full toolkit:
+
+- Overlay UI — live boundary tree, Suspense markers, bundle bytes, hydration timings
+- Flight tap & timeline — capture React Flight streaming; visualize chunk order, sizes, labels
+- Cache lens — inspect `tags`, revalidate policies, and route impact
+- Waterfall detector — find sequential awaits; guided fixes (preload/parallelize)
+- Codemods — `use client`, wrap with Suspense, add preload/hydration hook
+- VS Code extension — analyzer diagnostics + “Open in XRay” deep links
+- CI budgets & trends — PR comments, thresholds, and historical deltas
+
+Learn more → https://rsc-xray.dev • Pricing → https://rsc-xray.dev/pricing

--- a/packages/report-html/package.json
+++ b/packages/report-html/package.json
@@ -4,6 +4,16 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "keywords": [
+    "react-server-components",
+    "rsc",
+    "nextjs",
+    "debug",
+    "observability",
+    "report",
+    "html",
+    "visualization"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/schemas/README.md
+++ b/packages/schemas/README.md
@@ -1,5 +1,8 @@
 # @rsc-xray/schemas
 
+[![npm](https://img.shields.io/npm/v/@rsc-xray/schemas.svg)](https://www.npmjs.com/package/@rsc-xray/schemas)
+[![Downloads](https://img.shields.io/npm/dm/@rsc-xray/schemas.svg)](https://www.npmjs.com/package/@rsc-xray/schemas)
+
 Shared TypeScript types and JSON schema that define the `model.json` contract between the analyzer, CLI, HTML report, and Pro tooling.
 
 ## What it solves
@@ -49,3 +52,17 @@ Run the schema tests with:
 ```bash
 pnpm -F @rsc-xray/schemas test -- --run
 ```
+
+### RSC X‑Ray Pro
+
+Paid plans available — unlock the full toolkit:
+
+- Overlay UI — live boundary tree, Suspense markers, bundle bytes, hydration timings
+- Flight tap & timeline — capture React Flight streaming; visualize chunk order, sizes, labels
+- Cache lens — inspect `tags`, revalidate policies, and route impact
+- Waterfall detector — find sequential awaits; guided fixes (preload/parallelize)
+- Codemods — `use client`, wrap with Suspense, add preload/hydration hook
+- VS Code extension — analyzer diagnostics + “Open in XRay” deep links
+- CI budgets & trends — PR comments, thresholds, and historical deltas
+
+Learn more → https://rsc-xray.dev • Pricing → https://rsc-xray.dev/pricing

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -4,6 +4,16 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "keywords": [
+    "react-server-components",
+    "rsc",
+    "nextjs",
+    "debug",
+    "observability",
+    "schema",
+    "json-schema",
+    "types"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
This PR updates OSS package READMEs with npm badges and adds keywords to manifests for discoverability. It also adds a Changeset to patch bump all affected packages so README updates land in published tarballs.\n\nPackages: @rsc-xray/analyzer, @rsc-xray/cli, @rsc-xray/schemas, @rsc-xray/report-html, @rsc-xray/hydration.\n\nCloses #69