### PR TITLE
chore: version OSS packages (readme badges + keywords)

### DIFF
--- a/.changeset/oss-readme-badges-and-keywords.md
+++ b/.changeset/oss-readme-badges-and-keywords.md
@@ -1,9 +1,0 @@
----
-'@rsc-xray/analyzer': patch
-'@rsc-xray/cli': patch
-'@rsc-xray/schemas': patch
-'@rsc-xray/report-html': patch
-'@rsc-xray/hydration': patch
----
-
-chore(docs): add npm badges to package READMEs and keywords to manifests for improved discovery; include updated README content in published tarballs.

--- a/examples/next-app/package.json
+++ b/examples/next-app/package.json
@@ -11,7 +11,7 @@
     "test:lighthouse": "pnpm exec tsx scripts/runLighthouse.ts"
   },
   "dependencies": {
-    "@rsc-xray/hydration": "workspace:^0.2.0",
+    "@rsc-xray/hydration": "workspace:^0.2.1",
     "next": "14.2.5",
     "react": "18.3.1",
     "react-dom": "18.3.1"

--- a/packages/analyzer/CHANGELOG.md
+++ b/packages/analyzer/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @rsc-xray/analyzer
 
+## 0.2.1
+
+### Patch Changes
+
+- 610e586: chore(docs): add npm badges to package READMEs and keywords to manifests for improved discovery; include updated README content in published tarballs.
+- Updated dependencies [610e586]
+  - @rsc-xray/schemas@0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/analyzer/package.json
+++ b/packages/analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsc-xray/analyzer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -26,7 +26,7 @@
     "test": "vitest --run"
   },
   "dependencies": {
-    "@rsc-xray/schemas": "workspace:^0.2.0"
+    "@rsc-xray/schemas": "workspace:^0.2.1"
   },
   "files": [
     "README.md",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @rsc-xray/cli
 
+## 0.2.1
+
+### Patch Changes
+
+- 610e586: chore(docs): add npm badges to package READMEs and keywords to manifests for improved discovery; include updated README content in published tarballs.
+- Updated dependencies [610e586]
+  - @rsc-xray/analyzer@0.2.1
+  - @rsc-xray/schemas@0.2.1
+  - @rsc-xray/report-html@0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsc-xray/cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,9 +22,9 @@
     "report": "tsx src/bin/report.ts"
   },
   "dependencies": {
-    "@rsc-xray/analyzer": "workspace:^0.2.0",
-    "@rsc-xray/report-html": "workspace:^0.2.0",
-    "@rsc-xray/schemas": "workspace:^0.2.0",
+    "@rsc-xray/analyzer": "workspace:^0.2.1",
+    "@rsc-xray/report-html": "workspace:^0.2.1",
+    "@rsc-xray/schemas": "workspace:^0.2.1",
     "ajv": "^8.17.1"
   },
   "exports": {

--- a/packages/hydration/CHANGELOG.md
+++ b/packages/hydration/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rsc-xray/hydration
 
+## 0.2.1
+
+### Patch Changes
+
+- 610e586: chore(docs): add npm badges to package READMEs and keywords to manifests for improved discovery; include updated README content in published tarballs.
+
 ## 0.2.0
 
 ## 0.1.2

--- a/packages/hydration/package.json
+++ b/packages/hydration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsc-xray/hydration",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/report-html/CHANGELOG.md
+++ b/packages/report-html/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @rsc-xray/report-html
 
+## 0.2.1
+
+### Patch Changes
+
+- 610e586: chore(docs): add npm badges to package READMEs and keywords to manifests for improved discovery; include updated README content in published tarballs.
+- Updated dependencies [610e586]
+  - @rsc-xray/schemas@0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/report-html/package.json
+++ b/packages/report-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsc-xray/report-html",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -25,7 +25,7 @@
     "test": "vitest --run --passWithNoTests"
   },
   "dependencies": {
-    "@rsc-xray/schemas": "workspace:^0.2.0"
+    "@rsc-xray/schemas": "workspace:^0.2.1"
   },
   "files": [
     "README.md",

--- a/packages/schemas/CHANGELOG.md
+++ b/packages/schemas/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rsc-xray/schemas
 
+## 0.2.1
+
+### Patch Changes
+
+- 610e586: chore(docs): add npm badges to package READMEs and keywords to manifests for improved discovery; include updated README content in published tarballs.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsc-xray/schemas",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Apply Changesets version bump for OSS packages so README updates and keywords are published. Follows #69.