### PR TITLE
Analyzer: infer dynamic rendering via cookies()/headers()/noStore()

### DIFF
--- a/packages/analyzer/src/lib/__tests__/cacheMetadata.test.ts
+++ b/packages/analyzer/src/lib/__tests__/cacheMetadata.test.ts
@@ -69,4 +69,30 @@ describe('collectCacheMetadata', () => {
     expect(meta.exportedDynamic).toBe('force-dynamic');
     expect(meta.experimentalPpr).toBe(true);
   });
+
+  it('marks dynamic when using cookies()/headers() from next/headers', () => {
+    const source = `
+      import { cookies, headers, draftMode } from 'next/headers';
+      export default function Page() {
+        headers();
+        cookies();
+        draftMode();
+        return null;
+      }
+    `;
+    const meta = collectCacheMetadata({ sourceText: source });
+    expect(meta.usesDynamicApis).toBe(true);
+  });
+
+  it('marks dynamic when using noStore()/unstable_noStore() from next/cache', () => {
+    const source = `
+      import { noStore, unstable_noStore } from 'next/cache';
+      export async function loader() {
+        noStore();
+        unstable_noStore();
+      }
+    `;
+    const meta = collectCacheMetadata({ sourceText: source });
+    expect(meta.usesDynamicApis).toBe(true);
+  });
 });

--- a/packages/analyzer/src/lib/cacheMetadata.ts
+++ b/packages/analyzer/src/lib/cacheMetadata.ts
@@ -9,6 +9,7 @@ export interface FileCacheMetadata {
   revalidatePathCalls: Set<string>;
   exportedDynamic?: 'auto' | 'force-dynamic' | 'force-static' | 'error';
   experimentalPpr: boolean;
+  usesDynamicApis: boolean;
 }
 
 interface CollectOptions {
@@ -27,6 +28,7 @@ function createEmptyMetadata(): FileCacheMetadata {
     revalidateTagCalls: new Set<string>(),
     revalidatePathCalls: new Set<string>(),
     experimentalPpr: false,
+    usesDynamicApis: false,
   };
 }
 
@@ -175,7 +177,37 @@ export function collectCacheMetadata({ sourceText }: CollectOptions): FileCacheM
     ts.ScriptKind.TSX
   );
 
+  // Track local identifiers imported for dynamic APIs
+  const headersIdents = new Set<string>();
+  const cookiesIdents = new Set<string>();
+  const draftModeIdents = new Set<string>();
+  const noStoreIdents = new Set<string>();
+
   const visit = (node: ts.Node) => {
+    // import { cookies, headers, draftMode } from 'next/headers'
+    // import { noStore, unstable_noStore } from 'next/cache'
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      const module = node.moduleSpecifier.text;
+      const bindings = node.importClause?.namedBindings;
+      if (bindings && ts.isNamedImports(bindings)) {
+        for (const element of bindings.elements) {
+          const importedNode = element.propertyName ?? element.name;
+          const importedName = ts.isIdentifier(importedNode) ? importedNode.text : undefined;
+          const localName = ts.isIdentifier(element.name) ? element.name.text : undefined;
+          if (!localName) continue;
+          if (module === 'next/headers') {
+            if (importedName === 'headers') headersIdents.add(localName);
+            if (importedName === 'cookies') cookiesIdents.add(localName);
+            if (importedName === 'draftMode') draftModeIdents.add(localName);
+          } else if (module === 'next/cache') {
+            if (importedName === 'noStore' || importedName === 'unstable_noStore') {
+              noStoreIdents.add(localName);
+            }
+          }
+        }
+      }
+    }
+
     if (
       ts.isVariableStatement(node) &&
       node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)
@@ -231,6 +263,14 @@ export function collectCacheMetadata({ sourceText }: CollectOptions): FileCacheM
         if (ts.isObjectLiteralExpression(options)) {
           collectCacheFromObjectLiteral(options, metadata);
         }
+      } else if (
+        ts.isIdentifier(node.expression) &&
+        (headersIdents.has(node.expression.text) ||
+          cookiesIdents.has(node.expression.text) ||
+          draftModeIdents.has(node.expression.text) ||
+          noStoreIdents.has(node.expression.text))
+      ) {
+        metadata.usesDynamicApis = true;
       } else if (isIdentifierWithName(node.expression, 'revalidateTag')) {
         const [first] = node.arguments;
         if (first && ts.isExpression(first)) {

--- a/packages/analyzer/src/lib/graph.ts
+++ b/packages/analyzer/src/lib/graph.ts
@@ -109,6 +109,8 @@ function createRouteCacheMetadata(
 
   if (meta.exportedDynamic) {
     cache.dynamic = meta.exportedDynamic;
+  } else if (meta.usesDynamicApis) {
+    cache.dynamic = 'force-dynamic';
   }
 
   if (meta.experimentalPpr) {
@@ -281,7 +283,9 @@ export async function buildGraph({
             (a, b) => a - b
           );
           const hasRevalidateFalse = cacheMetadata.hasRevalidateFalse;
-          const dynamic = cacheMetadata.exportedDynamic;
+          const dynamic =
+            cacheMetadata.exportedDynamic ??
+            (cacheMetadata.usesDynamicApis ? 'force-dynamic' : undefined);
           const experimentalPpr = cacheMetadata.experimentalPpr;
 
           if (


### PR DESCRIPTION
- Detects Next dynamic APIs (headers, cookies, draftMode from 'next/headers'; noStore/unstable_noStore from 'next/cache') in source files.\n- Sets node cache dynamic to 'force-dynamic' when used (unless explicit dynamic export set).\n- Sets route cache dynamic to 'force-dynamic' when the page file uses these APIs.\n- Adds unit tests for cache metadata collection and analyzeProject integration.\n\nCloses #72