### PR TITLE
chore(ci): allow lockfile refresh in version:packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format:check": "pnpm exec prettier --check .",
     "prepare": "husky",
     "changeset": "changeset",
-    "version:packages": "changeset version && pnpm install",
+    "version:packages": "changeset version && pnpm install --no-frozen-lockfile",
     "release": "changeset publish"
   },
   "devDependencies": {


### PR DESCRIPTION
Small CI improvement: let version script refresh lockfile.\n\n- changeset version && pnpm install --no-frozen-lockfile\n\nThis prevents failures when specifiers change during the version bump.\n