### PR TITLE
docs: explain HTML report contents and improve user clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ pnpm -F @rsc-xray/cli report --model ./model.json --out ./report.html
 
 `model.json` and `report.html` are written relative to your working directory (the repo root in this example).
 
+### What's in the HTML Report?
+
+The static HTML report shows:
+
+- **Bundle Analysis** - Total bytes, client/server split, per-route breakdown
+- **Component Tree** - Server/client boundaries with `'use client'` markers
+- **Suspense Boundaries** - Where streaming happens, boundary placement
+- **Diagnostics** - Rule violations with specific file/line numbers
+- **Suggestions** - Actionable fixes (hoist fetch, parallelize, add Suspense)
+- **Build Info** - Next.js version, build timestamp, route count
+
+**Perfect for:** Sharing with teammates, uploading to CI artifacts, offline review
+
+**Want live tracking?** See [RSC XRay Pro](#rsc-xray-pro) for interactive overlay, trends dashboard, and CI budgets.
+
 ## Flight Tap
 
 Capture RSC/Flight streaming timings while the demo is running:


### PR DESCRIPTION
## Summary
Addresses end-user clarity gap: users run `scx report` but don't know what they'll see in the HTML output.

## Changes

### What's in the HTML Report?
Added comprehensive section explaining report contents:
- **Bundle Analysis** - Total bytes, client/server split, per-route breakdown
- **Component Tree** - Server/client boundaries with `'use client'` markers
- **Suspense Boundaries** - Where streaming happens, boundary placement
- **Diagnostics** - Rule violations with specific file/line numbers
- **Suggestions** - Actionable fixes (hoist fetch, parallelize, add Suspense)
- **Build Info** - Next.js version, build timestamp, route count

### Use Cases
Added clear use cases:
- Perfect for: Sharing with teammates, uploading to CI artifacts, offline review
- Cross-link to Pro features for advanced workflows

## Impact
Users now understand the value of running `scx report` before they run it, improving adoption and reducing confusion.

## Related
- Part of comprehensive documentation overhaul
- Companion to Pro README updates (rsc-xray-pro#142)
- Addresses user question about tool clarity