### PR TITLE
fix(analyzer): add missing .js extension to clientForbiddenImports import

### DIFF
--- a/packages/analyzer/src/lib/analyzeProject.ts
+++ b/packages/analyzer/src/lib/analyzeProject.ts
@@ -19,7 +19,7 @@ import { classifyFiles } from './classifyFiles.js';
 import { readManifests } from './readManifests.js';
 import { collectSuggestionsForSource } from './suggestions.js';
 import { collectCacheMetadata, type FileCacheMetadata } from './cacheMetadata.js';
-import { analyzeClientFileForForbiddenImports } from '../rules/clientForbiddenImports';
+import { analyzeClientFileForForbiddenImports } from '../rules/clientForbiddenImports.js';
 import { detectClientSizeIssues } from '../rules/clientSizeThreshold.js';
 import { analyzeSerializationBoundary } from '../rules/serializationBoundary.js';
 import { readFlightSnapshot, readHydrationSnapshot } from './snapshots.js';


### PR DESCRIPTION
## Summary

Fixed the last remaining ES module import missing `.js` extension.

## Problem

One import in `analyzeProject.ts` was missed by the `sed` command in PR #116:
```ts
import { analyzeClientFileForForbiddenImports } from '../rules/clientForbiddenImports';
```

This causes module resolution errors in Node.js ES modules.

## Impact

- Blocks Pro LSP server from using @rsc-xray/analyzer@0.6.2
- Blocks comprehensive testing
- **Critical blocker** for phase completion

## Tests

✅ All 190 OSS tests passing  
✅ Build successful

## Next Steps

After merge, we need v0.6.3 release to unblock Pro LSP comprehensive testing.

Closes #122