### PR TITLE
fix(demo): Simplify Vercel build to use published npm packages

### DIFF
--- a/examples/demo/vercel.json
+++ b/examples/demo/vercel.json
@@ -1,4 +1,4 @@
 {
-  "buildCommand": "cd ../.. && pnpm install && pnpm --filter @rsc-xray/lsp-server build && pnpm --filter @rsc-xray/schemas build && pnpm --filter @rsc-xray/analyzer build && cd examples/demo && pnpm build",
-  "installCommand": "cd ../.. && pnpm install"
+  "buildCommand": "pnpm install && pnpm build",
+  "installCommand": "pnpm install"
 }


### PR DESCRIPTION
Fixes Vercel deployment by removing workspace build commands.

The demo now uses published npm packages, so we don't need to build workspace dependencies from source.

**Changes:**
- Simplified buildCommand to just `pnpm install && pnpm build`
- Simplified installCommand to just `pnpm install`
- Dependencies will be fetched from npm registry

This should fix the `tsc: command not found` error on Vercel.