### PR TITLE
fix(demo): add typescript as explicit dependency for Vercel

### DIFF
--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -23,7 +23,8 @@
     "codemirror": "^6.0.2",
     "next": "^15.2.3",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "typescript": "^5.6.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.47.0",

--- a/examples/demo/pnpm-lock.yaml
+++ b/examples/demo/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
     devDependencies:
       '@playwright/test':
         specifier: ^1.47.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      typescript:
+        specifier: ^5.6.0
+        version: 5.6.2
     devDependencies:
       '@playwright/test':
         specifier: ^1.47.0


### PR DESCRIPTION
## Problem
Vercel build failed with:
```
Type error: Cannot find module 'typescript' or its corresponding type declarations.
```

## Root Cause
The demo's API route (`app/api/analyze/route.ts`) imports `typescript` directly:
```typescript
import * as ts from 'typescript';
```

While `typescript` is a dependency of `@rsc-xray/analyzer`, it's not accessible in the demo app when using `pnpm install --ignore-workspace --frozen-lockfile` (Vercel's install command).

## Solution
Added `typescript: ^5.6.0` as an explicit dependency of the demo app.

## Testing
✅ Local Vercel build simulation:
```bash
cd examples/demo
rm -rf node_modules .next
pnpm install --ignore-workspace --frozen-lockfile
pnpm build  # ✓ SUCCESS
```

## Related
- Fixes Vercel deployment failure in PR #156
- Required for live demo at https://rsc-xray-demo.vercel.app