### PR TITLE
fix(ci): skip Vercel dry build in CI environments

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,8 +3,9 @@
 
 set -e
 
-if [ "$SKIP_DRY" = "1" ]; then
-  echo "Skipping dry Vercel build (SKIP_DRY=1)."
+# Skip dry build in CI environments
+if [ "$CI" = "true" ] || [ "$SKIP_DRY" = "1" ]; then
+  echo "Skipping dry Vercel build (CI or SKIP_DRY=1)."
   exit 0
 fi
 


### PR DESCRIPTION
## Problem
The changesets publish workflow was failing with:
```
ERR_PNPM_OUTDATED_LOCKFILE Cannot install with "frozen-lockfile"
because pnpm-lock.yaml is not up to date with package.json
```

## Root Cause
The pre-push hook runs `vercel:dry:demo` to validate the demo builds before pushing. During the changesets workflow:
1. Changesets action pushes version commits/tags
2. Pre-push hook triggers `vercel:dry:demo`
3. Demo lockfile may still reference workspace packages at that moment
4. `pnpm install --ignore-workspace --frozen-lockfile` fails

## Solution
Skip the Vercel dry build when `CI=true` (standard environment variable in GitHub Actions, GitLab CI, CircleCI, etc.).

Local developers still get pre-push validation.

## Testing
- ✅ Pre-push hook skips in CI (when `CI=true`)
- ✅ Pre-push hook still runs locally (when `CI` is unset)
- ✅ Can still manually skip with `SKIP_DRY=1 git push`

## Impact
- Fixes changesets publish workflow
- Maintains local developer guardrails
- No breaking changes