### PR TITLE
docs: update READMEs to mention VS Code extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 Analyze React Server Components in Next.js: boundaries, Suspense, bundle bytes, and suggestions — export a shareable offline HTML report.
 
-**Try it live**: [Interactive Demo](https://demo.rsc-xray.dev) — Edit code and see diagnostics in real-time
+**Try it live**: [Interactive Demo](https://demo.rsc-xray.dev) — Edit code and see diagnostics in real-time  
+**Get the extension**: [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=rsc-xray.rsc-xray-pro) (Pro) — Inline diagnostics with quick fixes
 
 ## Features (Free/OSS)
 
@@ -26,10 +27,11 @@ Analyze React Server Components in Next.js: boundaries, Suspense, bundle bytes, 
 - **Route segment config analyzer** — Validate and detect conflicts in route config options
 - Suggestions (hoist fetch, parallelize awaits, add Suspense boundaries)
 
-**Reporting:**
+**Reporting & Tools:**
 
 - Export JSON model and **offline HTML report**
-- Interactive demo at [demo.rsc-xray.dev](https://demo.rsc-xray.dev)
+- **Interactive browser demo** at [demo.rsc-xray.dev](https://demo.rsc-xray.dev)
+- **LSP server** for editor integrations (`@rsc-xray/lsp-server`)
 - Compatibility: Next.js 13.4–15.x
 
 <details>

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -31,14 +31,15 @@ Visit http://localhost:3001
 
 ## Dependencies
 
-This demo uses workspace dependencies (no npm publishing required for deployment):
+This demo uses published npm packages for Vercel deployment:
 
-- `@rsc-xray/lsp-server@workspace:*` - LSP orchestration layer
-- `@rsc-xray/schemas@workspace:*` - Type definitions
+- `@rsc-xray/lsp-server` - LSP orchestration layer
+- `@rsc-xray/schemas` - Type definitions
 - `@rsc-xray/analyzer` (transitive) - Core analysis engine
+- `typescript` - Required for API route TypeScript parsing
 
-Vercel resolves workspace packages via `pnpm-workspace.yaml` and `pnpm-lock.yaml`.
-During local development, workspace packages are linked automatically.
+During local monorepo development, these resolve to workspace packages automatically.  
+For Vercel deployment, the lockfile references published versions from npm registry.
 
 ## Editor Choice: CodeMirror 6
 


### PR DESCRIPTION
## Summary
Update OSS repository README files to reflect current state of the project.

## Changes

### Main README ()
- **Added VS Code extension link** at the top (Pro feature badge)
- **Updated 'Reporting' section** to 'Reporting & Tools' for clarity
- **Added LSP server** to feature list (enables editor integrations)

### Demo README ()
- **Clarified dependency resolution**: Uses published npm packages (not workspace dependencies) for Vercel
- **Added `typescript` to dependency list** (required for API route parsing)
- **Explained dual-mode resolution**: workspace links for local dev, npm packages for deployment

## Why
The VS Code extension is live and published, but wasn't mentioned in the main OSS README. The demo README was outdated regarding its dependency strategy after we switched to published packages for Vercel deployment.

## Testing
- ✅ README markdown renders correctly on GitHub
- ✅ All links point to correct locations
- ✅ Information is accurate and up-to-date